### PR TITLE
chore(ci): add checkout step in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,6 +48,8 @@ jobs:
       GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Copy compose to server
         uses: appleboy/scp-action@v0.1.7
         with:


### PR DESCRIPTION
Include a checkout step in the continuous deployment workflow to ensure the repository is available for subsequent actions. This enhancement improves the reliability of the deployment process by allowing access to the latest codebase.