### PR TITLE
chore(ci): simplify target directory preparation in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -58,9 +58,7 @@ jobs:
           script_stop: true
           script: |
             set -e
-            sudo mkdir -p "$APP_DIR"
-            sudo chown -R "$SSH_USER":"$SSH_USER" "$APP_DIR"
-            sudo chmod 755 "$APP_DIR"
+            mkdir -p "$APP_DIR"
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Copy compose to server


### PR DESCRIPTION
Refactor the continuous deployment workflow by removing unnecessary sudo commands for creating the target directory. This change streamlines the setup process while maintaining the necessary directory structure for deployment.