### PR TITLE
chore(ci): enhance target directory creation log in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -58,7 +58,8 @@ jobs:
           script_stop: true
           script: |
             set -e
-            mkdir -p "$APP_DIR"
+            echo "creating: ${{ env.APP_DIR }} as user: ${{ env.SSH_USER }}"
+            mkdir -p "${{ env.APP_DIR }}"
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Copy compose to server


### PR DESCRIPTION
Add logging to the target directory creation step in the continuous deployment workflow to provide clearer feedback on the directory being created and the user executing the command. This improves visibility during the deployment process.